### PR TITLE
Evaluation scaling

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -29,7 +29,7 @@ Value evaluate(Position* pos) {
     // Damp down the evaluation linearly when shuffling
     v = v * (100 - rule50_count()) / 100;
 
-    v = 110 * v / 100;
+    v = 120 * v / 100;
 
     // v = (v / 16) * 16;
     // v = (stm() == WHITE ? v : -v) + Tempo


### PR DESCRIPTION
```
Elo   | 3.27 +- 2.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20638 W: 5043 L: 4849 D: 10746
Penta | [166, 2399, 5003, 2577, 174]
```