### PR TITLE
Simplify low ply history away

### DIFF
--- a/src/movepick.c
+++ b/src/movepick.c
@@ -88,7 +88,6 @@ SMALL
 static void score_quiets(const Position* pos) {
     Stack*            st      = pos->st;
     ButterflyHistory* history = pos->history;
-    LowPlyHistory*    lph     = pos->lowPlyHistory;
 
     PieceToHistory* cmh  = (st - 1)->history;
     PieceToHistory* fmh  = (st - 2)->history;
@@ -106,8 +105,7 @@ static void score_quiets(const Position* pos) {
                  + mp_v5 * (*cmh)[piece_on(from)][to]
                  + mp_v6 * (*fmh)[piece_on(from)][to]
                  + mp_v7 * (*fmh2)[piece_on(from)][to]
-                 + mp_v8 * (*fmh3)[piece_on(from)][to]
-                 + mp_v9 * (st->mp_ply < MAX_LPH ? min((mp_v10 / 100), st->depth / (mp_v11 / 100)) * (*lph)[st->mp_ply][move] : 0)) / 100;
+                 + mp_v8 * (*fmh3)[piece_on(from)][to]) / 100;
     }
 }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -45,11 +45,6 @@ static void cpth_update(CapturePieceToHistory history, Piece pc, Square to, int 
     history[pc][to][captured] += v - history[pc][to][captured] * abs(v) / 10692;
 }
 
-static void lph_update(LowPlyHistory history, int ply, Move m, int v) {
-    m &= 4095;
-    history[ply][m] += v - history[ply][m] * abs(v) / 10692;
-}
-
 enum {
     ST_MAIN_SEARCH,
     ST_CAPTURES_INIT,

--- a/src/position.h
+++ b/src/position.h
@@ -163,7 +163,6 @@ struct Position {
     // Pointers to thread-specific tables.
     CounterMoveStat*        counterMoves;
     ButterflyHistory*       history;
-    LowPlyHistory*          lowPlyHistory;
     CapturePieceToHistory*  captureHistory;
     correction_history_t    corrHistory;
     CounterMoveHistoryStat* counterMoveHistory;

--- a/src/thread.c
+++ b/src/thread.c
@@ -71,7 +71,6 @@ static THREAD_FUNC thread_init(void* arg) {
     pos->counterMoves    = calloc(sizeof(CounterMoveStat), 1);
     pos->history         = calloc(sizeof(ButterflyHistory), 1);
     pos->captureHistory  = calloc(sizeof(CapturePieceToHistory), 1);
-    pos->lowPlyHistory   = calloc(sizeof(LowPlyHistory), 1);
     pos->rootMoves       = calloc(sizeof(RootMoves), 1);
     pos->stackAllocation = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
     pos->moveList        = calloc(10000 * sizeof(ExtMove), 1);
@@ -157,7 +156,6 @@ static void thread_destroy(Position* pos) {
     free(pos->counterMoves);
     free(pos->history);
     free(pos->captureHistory);
-    free(pos->lowPlyHistory);
     free(pos->rootMoves);
     free(pos->stackAllocation);
     free(pos->moveList);

--- a/src/types.h
+++ b/src/types.h
@@ -407,9 +407,6 @@ typedef struct PawnEntry     PawnEntry;
 typedef struct MaterialEntry MaterialEntry;
 
 enum {
-    MAX_LPH = 4
-};
-enum {
     CORRECTION_HISTORY_ENTRY_NB = 4096,
     CORRECTION_HISTORY_MAX      = 8192,
 };
@@ -419,7 +416,6 @@ typedef int16_t        PieceToHistory[16][64];
 typedef PieceToHistory CounterMoveHistoryStat[16][64];
 typedef int16_t        ButterflyHistory[2][4096];
 typedef int16_t        CapturePieceToHistory[16][64][8];
-typedef int16_t        LowPlyHistory[MAX_LPH][4096];
 typedef int32_t        correction_history_t[2][CORRECTION_HISTORY_ENTRY_NB];
 
 struct ExtMove {


### PR DESCRIPTION
Based on: https://github.com/official-stockfish/Stockfish/commit/dc5d9bdfee70f4267d9a49ad71e5ee478dd50ca5 https://github.com/official-stockfish/Stockfish/commit/54a989930ebed200c3278c725151e26a2c0da37a
```
Elo   | 4.66 +- 4.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6556 W: 1740 L: 1652 D: 3164
Penta | [52, 773, 1548, 845, 60]
```