### PR TITLE
Simplify LMR conditions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -955,9 +955,8 @@ moves_loop:  // When in check search starts from here.
 
         // Step 16. Reduced depth search (LMR). If the move fails high it will be
         // re-searched at full depth.
-        if (depth >= 3 && moveCount > 1 + 2 * rootNode + 2 * (PvNode && abs(bestValue) < 2)
-            && (!captureOrPromotion || moveCountPruning
-                || ss->staticEval + *PieceValue[EG][captured_piece()] <= alpha || cutNode))
+        if (depth >= 3 && moveCount > 1 + 2 * rootNode
+            && (!captureOrPromotion || cutNode || (!PvNode && !formerPv)))
         {
             Depth r = reduction(improving, depth, moveCount);
 


### PR DESCRIPTION
```
Elo   | 1.59 +- 3.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 13530 W: 3531 L: 3469 D: 6530
Penta | [122, 1643, 3176, 1699, 125]
```