### PR TITLE
Simplify futility pruning for captures

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -794,10 +794,7 @@ moves_loop:  // When in check search starts from here.
 
                 // Futility pruning for captures
                 if (!givesCheck && lmrDepth < sfpc_v1 / 100
-                    && !(PvNode && abs(bestValue) < sfpc_v2 / 100)
-                    && PieceValue[type_of_p(movedPiece)]
-                         >= PieceValue[type_of_p(piece_on(to_sq(move)))]
-                    && !inCheck
+                    && !(PvNode && abs(bestValue) < sfpc_v2 / 100) && !inCheck
                     && ss->staticEval + sfpc_v3 + sfpc_v4 * lmrDepth
                            + PieceValue[type_of_p(piece_on(to_sq(move)))]
                          <= alpha)


### PR DESCRIPTION
```
Elo   | 7.18 +- 5.57 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 4644 W: 1171 L: 1075 D: 2398
Penta | [28, 548, 1087, 618, 41]
```