### PR TITLE
Micro-simplification for storing moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -473,7 +473,7 @@ Value search(
     if (depth <= 0)
         return qsearch(pos, ss, alpha, beta, 0, PvNode, checkers());
 
-    Move     pv[MAX_PLY + 1], capturesSearched[32], quietsSearched[64];
+    Move     pv[MAX_PLY + 1], capturesSearched[32], quietsSearched[32];
     TTEntry* tte;
     Key      posKey;
     Move     ttMove, move, excludedMove, bestMove;
@@ -1076,12 +1076,11 @@ moves_loop:  // When in check search starts from here.
             }
         }
 
-        if (move != bestMove)
+        if (move != bestMove && moveCount < 32)
         {
-            if (captureOrPromotion && captureCount < 32)
+            if (captureOrPromotion)
                 capturesSearched[captureCount++] = move;
-
-            else if (!captureOrPromotion && quietCount < 64)
+            else
                 quietsSearched[quietCount++] = move;
         }
     }


### PR DESCRIPTION
```
Elo   | 0.87 +- 2.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17128 W: 4214 L: 4171 D: 8743
Penta | [120, 2092, 4118, 2093, 141]
```