### PR TITLE
Simplify LMR case away

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -912,11 +912,6 @@ moves_loop:  // When in check search starts from here.
         {
             Depth r = reduction(improving, depth, moveCount);
 
-            // Decrease reduction at non-check cut nodes for second move at low
-            // depths
-            if (cutNode && depth <= lmr_v1 / 100 && moveCount <= 2 && !inCheck)
-                r--;
-
             // Decrease reduction if position is or has been on the PV
             if (ss->ttPv)
                 r -= 2;


### PR DESCRIPTION
```
Elo   | 0.87 +- 2.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17128 W: 4214 L: 4171 D: 8743
Penta | [120, 2092, 4118, 2093, 141]
```