### PR TITLE
Introduce pawn correction history

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -157,7 +157,8 @@ struct Position {
     CounterMoveStat*        counterMoves;
     ButterflyHistory*       history;
     CapturePieceToHistory*  captureHistory;
-    correction_history_t    corrHistory;
+    correction_history_t    matCorrHist;
+    correction_history_t    pawnCorrHist;
     CounterMoveHistoryStat* counterMoveHistory;
 
     // Thread-control data.
@@ -231,6 +232,7 @@ PURE bool is_draw(const Position* pos);
 // Accessing hash keys
 #define key() (pos->st->key)
 #define material_key() (pos->st->materialKey)
+#define pawn_key() (pos->st->pawnKey)
 
 // Other properties of the position
 #define stm() (pos->sideToMove)

--- a/src/types.h
+++ b/src/types.h
@@ -318,7 +318,7 @@ typedef struct PawnEntry     PawnEntry;
 typedef struct MaterialEntry MaterialEntry;
 
 enum {
-    CORRECTION_HISTORY_ENTRY_NB = 4096,
+    CORRECTION_HISTORY_ENTRY_NB = 16384,
     CORRECTION_HISTORY_MAX      = 8192,
 };
 


### PR DESCRIPTION
LLR: 2.92 (-2.25, 2.89) [0.00, 5.00]
Games: 2842 W: 751 L: 629 D: 1462
Ptnml(0-2): 14, 299, 681, 405, 22

bench: 443352