### PR TITLE
Fix non-deterministic behavior between searches

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -157,8 +157,8 @@ struct Position {
     CounterMoveStat*        counterMoves;
     ButterflyHistory*       history;
     CapturePieceToHistory*  captureHistory;
-    correction_history_t    matCorrHist;
-    correction_history_t    pawnCorrHist;
+    correction_history_t*   matCorrHist;
+    correction_history_t*   pawnCorrHist;
     CounterMoveHistoryStat* counterMoveHistory;
 
     // Thread-control data.

--- a/src/search.c
+++ b/src/search.c
@@ -1132,9 +1132,9 @@ moves_loop:  // When in check search starts from here.
         && !(bestValue >= beta && bestValue <= ss->staticEval)
         && !(!bestMove && bestValue >= ss->staticEval))
     {
-        add_correction_history(pos->matCorrHist, stm(), material_key(), depth,
+        add_correction_history(*pos->matCorrHist, stm(), material_key(), depth,
                                bestValue - ss->staticEval);
-        add_correction_history(pos->pawnCorrHist, stm(), pawn_key(), depth,
+        add_correction_history(*pos->pawnCorrHist, stm(), pawn_key(), depth,
                                bestValue - ss->staticEval);
     }
 
@@ -1404,8 +1404,8 @@ add_correction_history(correction_history_t hist, Color side, Key key, Depth dep
 }
 
 Value to_corrected(Position* pos, Value rawEval) {
-    int32_t mch = pos->matCorrHist[stm()][material_key() % CORRECTION_HISTORY_ENTRY_NB];
-    int32_t pch = pos->pawnCorrHist[stm()][pawn_key() % CORRECTION_HISTORY_ENTRY_NB];
+    int32_t mch = (*pos->matCorrHist)[stm()][material_key() % CORRECTION_HISTORY_ENTRY_NB];
+    int32_t pch = (*pos->pawnCorrHist)[stm()][pawn_key() % CORRECTION_HISTORY_ENTRY_NB];
     Value   v   = rawEval + (pch + mch) / ch_v2;
     v           = clamp(v, -VALUE_MATE_IN_MAX_PLY, VALUE_MATE_IN_MAX_PLY);
     return v;

--- a/src/thread.c
+++ b/src/thread.c
@@ -32,6 +32,8 @@ void thread_init() {
     pos->counterMoves    = calloc(sizeof(CounterMoveStat), 1);
     pos->history         = calloc(sizeof(ButterflyHistory), 1);
     pos->captureHistory  = calloc(sizeof(CapturePieceToHistory), 1);
+    pos->matCorrHist     = calloc(sizeof(correction_history_t), 1);
+    pos->pawnCorrHist    = calloc(sizeof(correction_history_t), 1);
     pos->rootMoves       = calloc(sizeof(RootMoves), 1);
     pos->stackAllocation = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
     pos->moveList        = calloc(10000 * sizeof(ExtMove), 1);


### PR DESCRIPTION
```
Elo   | -0.32 +- 1.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 36836 W: 8801 L: 8835 D: 19200
Penta | [270, 4455, 8979, 4467, 247]
```

Bench: 1680416