### PR TITLE
Simplify futility pruning for captures conditions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -78,7 +78,6 @@ PARAM(fpp_v2, 217)
 PARAM(fpp_v3, 184)
 PARAM(sqsee_v1, 2856)
 PARAM(sfpc_v1, 630)
-PARAM(sfpc_v2, 197)
 PARAM(sfpc_v3, 183)
 PARAM(sfpc_v4, 230)
 PARAM(scsee_v1, 199)
@@ -800,8 +799,7 @@ moves_loop:  // When in check search starts from here.
             else
             {
                 // Futility pruning for captures
-                if (!givesCheck && lmrDepth < sfpc_v1 / 100
-                    && !(PvNode && abs(bestValue) < sfpc_v2 / 100) && !inCheck
+                if (!givesCheck && lmrDepth < sfpc_v1 / 100 && !inCheck
                     && ss->staticEval + sfpc_v3 + sfpc_v4 * lmrDepth
                            + PieceValue[type_of_p(piece_on(to_sq(move)))]
                          <= alpha)


### PR DESCRIPTION
```
Elo   | 7.75 +- 5.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 4034 W: 1025 L: 935 D: 2074
Penta | [26, 394, 1087, 484, 26]
```

Bench: 2526447