### PR TITLE
Use preliminary sorting in move picker

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -46,6 +46,8 @@
     #define SMALL
 #endif
 
+#define NOINLINE __attribute__((noinline))
+
 #if defined(USE_PEXT)
     #include <immintrin.h>  // Header for _pext_u64() intrinsic
     #define pext(b, m) _pext_u64(b, m)


### PR DESCRIPTION
STC simplification passed:
```
Elo   | 1.35 +- 3.14 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14190 W: 3503 L: 3448 D: 7239
Penta | [102, 1701, 3443, 1738, 111]
```

Adding `NOINLINE` to reduce binary size passed:
```
Elo   | -0.06 +- 2.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 29332 W: 7054 L: 7059 D: 15219
Penta | [155, 3105, 8159, 3084, 163]
```