### PR TITLE
Correction history based on a common prior move

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -151,6 +151,7 @@ struct Position {
     CapturePieceToHistory*   captureHistory;
     CorrectionHistory*       matCorrHist;
     CorrectionHistory*       pawnCorrHist;
+    CorrectionHistory*       prevMoveCorrHist;
     ContinuationHistoryStat* contHist;
 
     // Thread-control data.

--- a/src/thread.c
+++ b/src/thread.c
@@ -27,14 +27,15 @@ ThreadStruct Thread = {0};
 void thread_init() {
     Thread.testPonder = 0;
 
-    Position* pos        = calloc(sizeof(Position), 1);
-    pos->mainHistory     = calloc(sizeof(ButterflyHistory), 1);
-    pos->captureHistory  = calloc(sizeof(CapturePieceToHistory), 1);
-    pos->matCorrHist     = calloc(sizeof(CorrectionHistory), 1);
-    pos->pawnCorrHist    = calloc(sizeof(CorrectionHistory), 1);
-    pos->rootMoves       = calloc(sizeof(RootMoves), 1);
-    pos->stackAllocation = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
-    pos->moveList        = calloc(10000 * sizeof(ExtMove), 1);
+    Position* pos         = calloc(sizeof(Position), 1);
+    pos->mainHistory      = calloc(sizeof(ButterflyHistory), 1);
+    pos->captureHistory   = calloc(sizeof(CapturePieceToHistory), 1);
+    pos->matCorrHist      = calloc(sizeof(CorrectionHistory), 1);
+    pos->pawnCorrHist     = calloc(sizeof(CorrectionHistory), 1);
+    pos->prevMoveCorrHist = calloc(sizeof(CorrectionHistory), 1);
+    pos->rootMoves        = calloc(sizeof(RootMoves), 1);
+    pos->stackAllocation  = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
+    pos->moveList         = calloc(10000 * sizeof(ExtMove), 1);
 
     pos->stack    = (Stack*) (((uintptr_t) pos->stackAllocation + 0x3f) & ~0x3f);
     pos->contHist = calloc(sizeof(ContinuationHistoryStat), 1);
@@ -62,5 +63,6 @@ void thread_exit() {
     free(pos->contHist);
     free(pos->matCorrHist);
     free(pos->pawnCorrHist);
+    free(pos->prevMoveCorrHist);
     free(pos);
 }


### PR DESCRIPTION
```
Elo   | 3.09 +- 2.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28404 W: 7192 L: 6939 D: 14273
Penta | [192, 3376, 6837, 3581, 216]
```

Bench: 2033521