### PR TITLE
Simplify away qsearch continuation history pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1257,13 +1257,7 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
         prefetch(tt_first_entry(key_after(pos, move)));
 
         ss->currentMove         = move;
-        bool captureOrPromotion = is_capture_or_promotion(pos, move);
         ss->continuationHistory = &(*pos->contHist)[moved_piece(move)][to_sq(move)];
-
-        if (!captureOrPromotion && bestValue > VALUE_MATED_IN_MAX_PLY
-            && (*(ss - 1)->continuationHistory)[moved_piece(move)][to_sq(move)] < 0
-            && (*(ss - 2)->continuationHistory)[moved_piece(move)][to_sq(move)] < 0)
-            continue;
 
         // Make and search the move
         do_move(pos, move, givesCheck);


### PR DESCRIPTION
```
Elo   | -0.21 +- 1.60 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 53840 W: 13222 L: 13254 D: 27364
Penta | [358, 6529, 13194, 6465, 374]
```

Bench: 2155501