### PR TITLE
Simplify away improving heuristic in NMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -54,7 +54,6 @@ PARAM(nmp_v3, 165)
 PARAM(nmp_v4, 182)
 PARAM(nmp_v5, 25312)
 PARAM(nmp_v6, 27)
-PARAM(nmp_v7, 23)
 PARAM(nmp_v8, 92)
 PARAM(nmp_v9, 194)
 PARAM(qmo_v1, 367)
@@ -595,7 +594,7 @@ Value search(
     // Step 9. Null move search
     if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < nmp_v5
         && eval >= beta && eval >= ss->staticEval
-        && ss->staticEval >= beta - nmp_v6 * depth - nmp_v7 * improving + nmp_v8 * ss->ttPv + nmp_v9
+        && ss->staticEval >= beta - nmp_v6 * depth + nmp_v8 * ss->ttPv + nmp_v9
         && !excludedMove && non_pawn_material_c(stm()))
     {
         // Null move dynamic reduction based on depth and value


### PR DESCRIPTION
```
Elo   | -0.01 +- 1.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 78472 W: 19262 L: 19264 D: 39946
Penta | [524, 9479, 19235, 9471, 527]
```

Bench: 1740594