### PR TITLE
Introduce non-pawn correction history

### DIFF
--- a/src/position.c
+++ b/src/position.c
@@ -189,6 +189,7 @@ SMALL void pos_set(Position* pos, char* fen) {
 SMALL static void set_state(Position* pos, Stack* st) {
     st->key = st->materialKey = 0;
     st->pawnKey               = zob.noPawns;
+    st->nonPawnKey[WHITE] = st->nonPawnKey[BLACK] = 0;
 
     st->checkersBB = attackers_to(square_of(stm(), KING)) & pieces_c(!stm());
 
@@ -205,6 +206,8 @@ SMALL static void set_state(Position* pos, Stack* st) {
 
         if (pt == PAWN)
             st->pawnKey ^= zob.psq[piece_on(s)][s];
+        else
+            st->nonPawnKey[color_of(pc)] ^= zob.psq[pc][s];
     }
 
     if (st->epSquare != 0)
@@ -504,6 +507,7 @@ void do_move(Position* pos, Move m, int givesCheck) {
         nnue_add_piece(acc, captured, rto, wksq, bksq);
 
         key ^= zob.psq[captured][rfrom] ^ zob.psq[captured][rto];
+        st->nonPawnKey[us] ^= zob.psq[captured][rfrom] ^ zob.psq[captured][rto];
         captured = 0;
     }
     else if (captured)
@@ -519,6 +523,8 @@ void do_move(Position* pos, Move m, int givesCheck) {
 
             st->pawnKey ^= zob.psq[captured][capsq];
         }
+        else
+            st->nonPawnKey[them] ^= zob.psq[captured][capsq];
 
         nnue_remove_piece(acc, captured, capsq, wksq, bksq);
 
@@ -595,6 +601,8 @@ void do_move(Position* pos, Move m, int givesCheck) {
         // Reset ply counters.
         st->plyCounters = 0;
     }
+    else
+        st->nonPawnKey[us] ^= zob.psq[piece][from] ^ zob.psq[piece][to];
 
     // Update the key with the final value
     st->key = key;

--- a/src/position.h
+++ b/src/position.h
@@ -50,6 +50,7 @@ struct Stack {
     // Copied when making a move
     Key pawnKey;
     Key materialKey;
+    Key nonPawnKey[2];
     union {
         struct {
             uint8_t pliesFromNull;
@@ -140,6 +141,8 @@ struct Position {
     CorrectionHistory*       matCorrHist;
     CorrectionHistory*       pawnCorrHist;
     CorrectionHistory*       prevMoveCorrHist;
+    CorrectionHistory*       wNonPawnCorrHist;
+    CorrectionHistory*       bNonPawnCorrHist;
     ContinuationHistoryStat* contHist;
 
     // Thread-control data.
@@ -207,6 +210,8 @@ PURE bool is_draw(const Position* pos);
 #define key() (pos->st->key)
 #define material_key() (pos->st->materialKey)
 #define pawn_key() (pos->st->pawnKey)
+#define w_nonpawn_key() (pos->st->nonPawnKey[WHITE])
+#define b_nonpawn_key() (pos->st->nonPawnKey[BLACK])
 
 // Other properties of the position
 #define stm() (pos->sideToMove)

--- a/src/thread.c
+++ b/src/thread.c
@@ -33,6 +33,8 @@ void thread_init() {
     pos->matCorrHist      = calloc(sizeof(CorrectionHistory), 1);
     pos->pawnCorrHist     = calloc(sizeof(CorrectionHistory), 1);
     pos->prevMoveCorrHist = calloc(sizeof(CorrectionHistory), 1);
+    pos->wNonPawnCorrHist = calloc(sizeof(CorrectionHistory), 1);
+    pos->bNonPawnCorrHist = calloc(sizeof(CorrectionHistory), 1);
     pos->stackAllocation  = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
     pos->moveList         = calloc(10000 * sizeof(ExtMove), 1);
 
@@ -60,5 +62,7 @@ void thread_exit() {
     free(pos->matCorrHist);
     free(pos->pawnCorrHist);
     free(pos->prevMoveCorrHist);
+    free(pos->wNonPawnCorrHist);
+    free(pos->bNonPawnCorrHist);
     free(pos);
 }


### PR DESCRIPTION
```
Elo   | 9.28 +- 4.24 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7306 W: 1908 L: 1713 D: 3685
Penta | [23, 820, 1800, 959, 51]
```