### PR TITLE
Reduce binary size by unifying correction histories

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -138,11 +138,7 @@ struct Position {
     // Pointers to thread-specific tables.
     ButterflyHistory*        mainHistory;
     CapturePieceToHistory*   captureHistory;
-    CorrectionHistory*       matCorrHist;
-    CorrectionHistory*       pawnCorrHist;
-    CorrectionHistory*       prevMoveCorrHist;
-    CorrectionHistory*       wNonPawnCorrHist;
-    CorrectionHistory*       bNonPawnCorrHist;
+    CorrectionHistory*       corrHists;
     ContinuationHistoryStat* contHist;
 
     // Thread-control data.
@@ -212,6 +208,7 @@ PURE bool is_draw(const Position* pos);
 #define pawn_key() (pos->st->pawnKey)
 #define w_nonpawn_key() (pos->st->nonPawnKey[WHITE])
 #define b_nonpawn_key() (pos->st->nonPawnKey[BLACK])
+#define prev_move_key() (from_to((pos->st - 1)->currentMove))
 
 // Other properties of the position
 #define stm() (pos->sideToMove)

--- a/src/thread.c
+++ b/src/thread.c
@@ -27,16 +27,12 @@ ThreadStruct Thread = {0};
 void thread_init() {
     Thread.testPonder = 0;
 
-    Position* pos         = calloc(sizeof(Position), 1);
-    pos->mainHistory      = calloc(sizeof(ButterflyHistory), 1);
-    pos->captureHistory   = calloc(sizeof(CapturePieceToHistory), 1);
-    pos->matCorrHist      = calloc(sizeof(CorrectionHistory), 1);
-    pos->pawnCorrHist     = calloc(sizeof(CorrectionHistory), 1);
-    pos->prevMoveCorrHist = calloc(sizeof(CorrectionHistory), 1);
-    pos->wNonPawnCorrHist = calloc(sizeof(CorrectionHistory), 1);
-    pos->bNonPawnCorrHist = calloc(sizeof(CorrectionHistory), 1);
-    pos->stackAllocation  = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
-    pos->moveList         = calloc(10000 * sizeof(ExtMove), 1);
+    Position* pos        = calloc(sizeof(Position), 1);
+    pos->mainHistory     = calloc(sizeof(ButterflyHistory), 1);
+    pos->captureHistory  = calloc(sizeof(CapturePieceToHistory), 1);
+    pos->corrHists       = calloc(sizeof(CorrectionHistory), 1);
+    pos->stackAllocation = calloc(63 + (MAX_PLY + 110) * sizeof(Stack), 1);
+    pos->moveList        = calloc(10000 * sizeof(ExtMove), 1);
 
     pos->stack    = (Stack*) (((uintptr_t) pos->stackAllocation + 0x3f) & ~0x3f);
     pos->contHist = calloc(sizeof(ContinuationHistoryStat), 1);
@@ -58,11 +54,7 @@ void thread_exit() {
     free(pos->captureHistory);
     free(pos->stackAllocation);
     free(pos->moveList);
+    free(pos->corrHists);
     free(pos->contHist);
-    free(pos->matCorrHist);
-    free(pos->pawnCorrHist);
-    free(pos->prevMoveCorrHist);
-    free(pos->wNonPawnCorrHist);
-    free(pos->bNonPawnCorrHist);
     free(pos);
 }

--- a/src/types.h
+++ b/src/types.h
@@ -268,6 +268,7 @@ struct PVariation {
 };
 
 enum {
+    CORRECTION_HISTORY_NB       = 5,
     CORRECTION_HISTORY_ENTRY_NB = 8192,
     CORRECTION_HISTORY_MAX      = 8192,
 };
@@ -276,7 +277,7 @@ typedef int16_t        PieceToHistory[15][64];
 typedef PieceToHistory ContinuationHistoryStat[15][64];
 typedef int16_t        ButterflyHistory[2][4096];
 typedef int16_t        CapturePieceToHistory[15][64][8];
-typedef int16_t        CorrectionHistory[2][CORRECTION_HISTORY_ENTRY_NB];
+typedef int16_t        CorrectionHistory[2][CORRECTION_HISTORY_NB][CORRECTION_HISTORY_ENTRY_NB];
 
 struct ExtMove {
     Move move;


### PR DESCRIPTION
```
Elo   | 1.19 +- 3.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14878 W: 3703 L: 3652 D: 7523
Penta | [74, 1827, 3610, 1830, 98]
```

Bench: 2029078