### PR TITLE
Simplify TT saving in ProbCut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -654,9 +654,8 @@ Value search(
                 undo_move(pos, move);
                 if (value >= probCutBeta)
                 {
-                    if (!(ttHit && tte_depth(tte) >= depth - 3 && ttValue != VALUE_NONE))
-                        tte_save(tte, posKey, value_to_tt(value, ss->ply), ttPv, BOUND_LOWER,
-                                 depth - 3, move, unadjustedStaticEval);
+                    tte_save(tte, posKey, value_to_tt(value, ss->ply), ttPv, BOUND_LOWER, depth - 3,
+                             move, unadjustedStaticEval);
                     return value - (probCutBeta - beta);
                 }
             }


### PR DESCRIPTION
```
Elo   | 1.04 +- 1.96 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 34014 W: 8389 L: 8287 D: 17338
Penta | [193, 3942, 8643, 4028, 201]
```

Bench: 1985922