### PR TITLE
Simplify away node type in qsearch

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -461,7 +461,7 @@ Value search(
 
     // Dive into quiescense search when the depth reaches zero
     if (depth <= 0)
-        return qsearch(pos, ss, alpha, beta, 0, PvNode);
+        return qsearch(pos, ss, alpha, beta, 0);
 
     Move     capturesSearched[32], quietsSearched[32];
     TTEntry* tte;
@@ -645,7 +645,7 @@ Value search(
                 do_move(pos, move, givesCheck);
 
                 // Perform a preliminary qsearch to verify that the move holds
-                value = -qsearch(pos, ss + 1, -probCutBeta, -probCutBeta + 1, 0, false);
+                value = -qsearch(pos, ss + 1, -probCutBeta, -probCutBeta + 1, 0);
 
                 // If the qsearch held, perform the regular search
                 if (value >= probCutBeta)
@@ -1060,9 +1060,7 @@ moves_loop:  // When in check search starts from here.
 // qsearch() is the quiescence search function template, which is
 // called by the main search function with zero depth, or recursively with
 // further decreasing depth per call.
-Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, const int NT) {
-    const bool PvNode = NT == PV;
-
+Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth) {
     TTEntry* tte;
     Key      posKey;
     Move     ttMove, move, bestMove;
@@ -1090,7 +1088,7 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
     ttMove  = ttHit ? tte_move(tte) : 0;
     pvHit   = ttHit && tte_is_pv(tte);
 
-    if (!PvNode && ttHit && tte_depth(tte) >= ttDepth
+    if (ttHit && tte_depth(tte) >= ttDepth
         && ttValue != VALUE_NONE  // Only in case of TT access race
         && (ttValue >= beta ? (tte_bound(tte) & BOUND_LOWER) : (tte_bound(tte) & BOUND_UPPER)))
         return ttValue;
@@ -1136,7 +1134,7 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
             return bestValue;
         }
 
-        if (PvNode && bestValue > alpha)
+        if (bestValue > alpha)
             alpha = bestValue;
 
         futilityBase = bestValue + qsf_v1;
@@ -1202,7 +1200,7 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
         // Make and search the move
         do_move(pos, move, givesCheck);
 
-        value = -qsearch(pos, ss + 1, -beta, -alpha, depth - 1, PvNode);
+        value = -qsearch(pos, ss + 1, -beta, -alpha, depth - 1);
         undo_move(pos, move);
 
         // Check for a new best move

--- a/src/search.h
+++ b/src/search.h
@@ -49,7 +49,7 @@ void  search_init(void);
 void  search_clear(void);
 void  start_thinking(Position* root);
 void  prepare_for_search(Position* root);
-Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, int NT);
+Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth);
 Value search(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, bool cutNode, int NT);
 
 #endif


### PR DESCRIPTION
```
Elo   | 0.56 +- 1.71 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 46246 W: 11423 L: 11349 D: 23474
Penta | [288, 5522, 11437, 5580, 296]
```

Bench: 2832650