### PR TITLE
Simplify away `key_after`

### DIFF
--- a/src/position.c
+++ b/src/position.c
@@ -704,24 +704,6 @@ void do_null_move(Position* pos) {
 // See position.h for undo_null_move()
 
 
-// key_after() computes the new hash key after the given move. Needed
-// for speculative prefetch. It does not recognize special moves like
-// castling, en-passant and promotions.
-
-Key key_after(const Position* pos, Move m) {
-    Square from     = from_sq(m);
-    Square to       = to_sq(m);
-    Piece  pc       = piece_on(from);
-    Piece  captured = piece_on(to);
-    Key    k        = key() ^ zob.side;
-
-    if (captured)
-        k ^= zob.psq[captured][to];
-
-    return k ^ zob.psq[pc][to] ^ zob.psq[pc][from];
-}
-
-
 // Test whether SEE >= value.
 bool see_test(const Position* pos, Move m, int value) {
     if (unlikely(type_of_m(m) != NORMAL))

--- a/src/position.h
+++ b/src/position.h
@@ -166,7 +166,6 @@ static void undo_null_move(Position* pos);
 // Static exchange evaluation
 PURE bool see_test(const Position* pos, Move m, int value);
 
-PURE Key  key_after(const Position* pos, Move m);
 PURE bool is_draw(const Position* pos);
 
 // Position representation

--- a/src/search.c
+++ b/src/search.c
@@ -793,15 +793,14 @@ moves_loop:  // When in check search starts from here.
         newDepth += extension;
 
         // Speculative prefetch as early as possible
-        prefetch(tt_first_entry(key_after(pos, move)));
+        do_move(pos, move, givesCheck);
+        // Step 15. Make the move.
+        prefetch(tt_first_entry(key()));
 
         // Update the current move (this must be done after singular extension
         // search)
         ss->currentMove         = move;
         ss->continuationHistory = &(*pos->contHist)[movedPiece][to_sq(move)];
-
-        // Step 15. Make the move.
-        do_move(pos, move, givesCheck);
 
         r = r * r_v1;
 
@@ -1053,6 +1052,7 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
     bool     ttHit, pvHit, givesCheck;
     Depth    ttDepth;
     int      moveCount;
+    Piece    movedPiece;
 
     bestMove  = 0;
     moveCount = 0;
@@ -1176,14 +1176,15 @@ Value qsearch(Position* pos, Stack* ss, Value alpha, Value beta, Depth depth, co
                 continue;
         }
 
-        // Speculative prefetch as early as possible
-        prefetch(tt_first_entry(key_after(pos, move)));
-
-        ss->currentMove         = move;
-        ss->continuationHistory = &(*pos->contHist)[moved_piece(move)][to_sq(move)];
+        movedPiece = moved_piece(move);
 
         // Make and search the move
         do_move(pos, move, givesCheck);
+        // Speculative prefetch as early as possible
+        prefetch(tt_first_entry(key()));
+
+        ss->currentMove         = move;
+        ss->continuationHistory = &(*pos->contHist)[movedPiece][to_sq(move)];
 
         value = -qsearch(pos, ss + 1, -beta, -alpha, depth - 1, PvNode);
         undo_move(pos, move);


### PR DESCRIPTION
```
Elo   | -0.21 +- 2.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 33174 W: 8217 L: 8237 D: 16720
Penta | [205, 4063, 8065, 4055, 199]
```

Bench: 1969328