### PR TITLE
Fix maximum time scale calculation

### DIFF
--- a/src/timeman.c
+++ b/src/timeman.c
@@ -68,7 +68,7 @@ void time_init(Color us, int ply) {
     // game time for the current move, so also cap to 20% of available game time.
     opt_scale = min(tm_v13 / 10000.0 + my_sqrt(ply + tm_v14 / 100.0) / (double) tm_v15,
                     tm_v16 / 100.0 * Limits.time[us] / (double) timeLeft);
-    max_scale = min(tm_v17 / 100.0, tm_v18 / 100.0 + ply / tm_v19 / 100.0);
+    max_scale = min(tm_v17 / 100.0, tm_v18 / 100.0 + ply / (tm_v19 / 100.0));
 
     // Never use more than 80% of the available time for this move
     Time.optimumTime = opt_scale * timeLeft;


### PR DESCRIPTION
```
Elo   | 3.66 +- 2.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21902 W: 5420 L: 5189 D: 11293
Penta | [130, 2522, 5420, 2745, 134]
```

Bench: 2645369