### PR TITLE
Decouple best move instability from root depth

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -172,9 +172,8 @@ PARAM(tm_v17, 674, 29)
 PARAM(tm_v18, 416, 14)
 PARAM(tm_v19, 1186, 14)
 PARAM(tm_v20, 801, 14)
-PARAM(tm_v21, 1069, 7)
-PARAM(tm_v22, 225, 8)
-PARAM(tm_v23, 990, 12)
+PARAM(tm_v21, 100, 4)
+PARAM(tm_v22, 170, 7)
 
 LimitsType Limits;
 
@@ -423,7 +422,7 @@ void thread_search(Position* pos) {
             totBestMoveChanges += Thread.pos->bestMoveChanges;
             Thread.pos->bestMoveChanges = 0;
 
-            double bestMoveInstability = 1 + 1.7 * totBestMoveChanges;
+            double bestMoveInstability = (tm_v21 / 100.0) + (tm_v22 / 100.0) * totBestMoveChanges;
 
             double totalTime = time_optimum() * fallingEval * reduction * bestMoveInstability;
 


### PR DESCRIPTION
```
Elo   | 0.51 +- 1.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 47524 W: 11600 L: 11530 D: 24394
Penta | [288, 5717, 11676, 5799, 282]
```