### PR TITLE
Simplify PV stability in time management

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -30,7 +30,6 @@ typedef struct ThreadStruct ThreadStruct;
 
 struct ThreadStruct {
     Position* pos;
-    double    previousTimeReduction;
     Value     previousScore;
     Value     iterValue[4];
     bool      ponder, stop;


### PR DESCRIPTION
```
Elo   | 1.55 +- 1.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 1.55 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44602 W: 10708 L: 10509 D: 23385
Penta | [247, 5311, 10968, 5546, 229]
```

Merging as a simplification
```
Bounds: [-3, 1]
Elo: 1.55 (-1.72 / +1.72) [-0.17 to 3.27]
nElo: 2.90 (-3.22 / +3.22) [-0.33 to 6.12]
Gamepairs Elo: 3.38 (-3.25 / +3.25) [0.13 to 6.63]
LLR: 5.7597
```