### PR TITLE
Simplify prior move history update

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -128,7 +128,6 @@ PARAM(mat_b, 715, 78.0)
 PARAM(mat_r, 1477, 120.0)
 PARAM(mat_q, 2567, 240.0)
 PARAM(pcmb_v1, 79, 12.0)
-PARAM(pcmb_v3, 22, 4.8)
 PARAM(pcmb_v4, 154, 12.0)
 PARAM(pcmb_v5, 7, 0.5)
 PARAM(pcmb_v6, 110, 12.0)
@@ -950,8 +949,7 @@ moves_loop:  // When in check search starts from here.
     // Bonus for prior countermove that caused the fail low
     else if (!captured_piece() && prevSq != SQ_NONE)
     {
-        int bonus = pcmb_v1 * (depth > 4) + pcmb_v3 * !(PvNode || cutNode)
-                  + pcmb_v4 * ((ss - 1)->moveCount > pcmb_v5)
+        int bonus = pcmb_v1 * (depth > 4) + pcmb_v4 * ((ss - 1)->moveCount > pcmb_v5)
                   + pcmb_v6 * (!ss->checkersBB && bestValue <= ss->staticEval - pcmb_v7)
                   + 119 * (!(ss - 1)->checkersBB && bestValue <= -(ss - 1)->staticEval - 83);
 


### PR DESCRIPTION
```
Elo   | 1.34 +- 2.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 29354 W: 7172 L: 7059 D: 15123
Penta | [161, 3491, 7262, 3600, 163]
```