### PR TITLE
Simplify history-based reduction adjustment in LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -807,8 +807,7 @@ moves_loop:  // When in check search starts from here.
                               + (*pos->mainHistory)[!stm()][from_to(move)] - lmr_v3;
 
                 // Decrease/increase reduction for moves with a good/bad history.
-                if (!ss->checkersBB)
-                    r -= ss->statScore / lmr_v8 * r_v13;
+                r -= ss->statScore / lmr_v8 * r_v13;
             }
             else
             {


### PR DESCRIPTION
```
Elo   | 2.04 +- 2.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 22004 W: 5373 L: 5244 D: 11387
Penta | [116, 2638, 5380, 2737, 131]
```

Bench: 3043833