### PR TITLE
Only do NMP on cutnodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -569,7 +569,7 @@ Value search(
         return eval;
 
     // Step 7. Null move search
-    if (!PvNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < nmp_v5
+    if (cutNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < nmp_v5
         && eval >= beta && eval >= ss->staticEval
         && ss->staticEval >= beta - nmp_v6 * depth + nmp_v8 * ss->ttPv + nmp_v9 && !excludedMove
         && non_pawn_material(pos))
@@ -582,7 +582,7 @@ Value search(
 
         do_null_move(pos);
         ss->endMoves    = (ss - 1)->endMoves;
-        Value nullValue = -search(pos, ss + 1, -beta, -beta + 1, depth - R, !cutNode, false);
+        Value nullValue = -search(pos, ss + 1, -beta, -beta + 1, depth - R, false, false);
         undo_null_move(pos);
 
         if (nullValue >= beta)


### PR DESCRIPTION
same thing I changed in SF, here it was ~97%

Elo   | 1.26 +- 2.11 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 30664 W: 7513 L: 7402 D: 15749
Penta | [173, 3734, 7418, 3823, 184]

bench: 2575225