### PR TITLE
Update ProbCut and LMP depth margins

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -190,7 +190,7 @@ static Depth reduction(int i, Depth d, int mn) {
 }
 
 static int futility_move_count(bool improving, Depth depth) {
-    return improving ? 3 + depth * depth : (2 + depth * depth) / 2;
+    return improving ? 3 + depth * depth : (3 + depth * depth) / 2;
 }
 
 // History and stats update bonus, based on depth
@@ -594,7 +594,7 @@ Value search(
     // Step 8. ProbCut
     // If we have a good enough capture and a reduced search returns a value
     // much above beta, we can (almost) safely prune the previous move
-    if (!PvNode && depth > 4 && abs(beta) < VALUE_MATE_IN_MAX_PLY
+    if (!PvNode && depth > 3 && abs(beta) < VALUE_MATE_IN_MAX_PLY
         && !(ttHit && tte_depth(tte) >= depth - 3 && ttValue != VALUE_NONE
              && ttValue < probCutBeta))
     {


### PR DESCRIPTION
```
Elo   | 1.93 +- 1.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 55672 W: 13653 L: 13344 D: 28675
Penta | [331, 6557, 13750, 6868, 330]
```

Bench: 3046571