### PR TITLE
Simplify LMR conditions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -782,7 +782,7 @@ moves_loop:  // When in check search starts from here.
         r = r * r_v1;
 
         // Step 14. Late move reductions (LMR)
-        if (depth >= 2 && moveCount > 1 + 2 * rootNode && (!capture || cutNode || !ss->ttPv))
+        if (depth >= 2 && moveCount > 1 && (!capture || !ss->ttPv))
         {
             // Decrease reduction if position is or has been on the PV
             if (ss->ttPv)


### PR DESCRIPTION
```
Elo   | -0.12 +- 1.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 90530 W: 22015 L: 22045 D: 46470
Penta | [557, 10959, 22209, 11037, 503]
```

Bench: 2796929