### PR TITLE
Skip cut node reduction for the main killer

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -139,8 +139,7 @@ PARAM(pcmb_v11, 143, 8.4)
 PARAM(r_v2, 2454, 250.0)
 PARAM(r_v6, 1244, 150.0)
 PARAM(r_v7, 1087, 150.0)
-PARAM(r_v8, 1325, 150.0)
-PARAM(r_v9, 920, 150.0)
+PARAM(r_v8, 2245, 150.0)
 PARAM(r_v13, 998, 50.0)
 PARAM(ded_v1, 63, 7.2)
 PARAM(qb_v1, 182, 18.0)
@@ -788,8 +787,8 @@ moves_loop:  // When in check search starts from here.
             if (ss->ttPv)
                 r -= r_v2;
 
-            if (cutNode)
-                r += r_v8 + r_v9 * !capture;
+            if (cutNode && move != ss->killers[0])
+                r += r_v8;
 
             if (capture)
                 ss->statScore = 0;


### PR DESCRIPTION
```
Elo   | 1.31 +- 1.81 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 0.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41424 W: 10108 L: 9952 D: 21364
Penta | [231, 5016, 10083, 5130, 252]
```

Passing [-3, 1], LLR: 4.6977