### PR TITLE
Simplify away some NMP conditions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -568,8 +568,7 @@ Value search(
         return eval;
 
     // Step 7. Null move search
-    if (cutNode && (ss - 1)->currentMove != MOVE_NULL && (ss - 1)->statScore < nmp_v5
-        && eval >= beta && eval >= ss->staticEval
+    if (cutNode && (ss - 1)->currentMove != MOVE_NULL && eval >= beta
         && ss->staticEval >= beta - nmp_v6 * depth + nmp_v8 * ss->ttPv + nmp_v9 && !excludedMove
         && non_pawn_material(pos))
     {


### PR DESCRIPTION
```
Elo   | 1.09 +- 2.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 33166 W: 8120 L: 8016 D: 17030
Penta | [187, 3999, 8124, 4069, 204]
```