### PR TITLE
Protection against extreme correction history updates

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1227,16 +1227,16 @@ static void update_correction_histories(const Position* pos, Depth depth, int32_
     Key keys[] = {pawn_key(),      prev_move_key(), w_nonpawn_key(),
                   b_nonpawn_key(), minor_key(),     major_key()};
 
+    int32_t newWeight  = min(ch_v1, 1 + depth);
+    int32_t scaledDiff = clamp(diff * ch_v2, -32768, 32768);
+
 #pragma clang loop unroll(disable)
     for (size_t i = 0; i < CORRECTION_HISTORY_NB; i++)
     {
-        int16_t* entry = &(*pos->corrHists)[stm()][i][keys[i] & CORRECTION_HISTORY_MASK];
+        int16_t* entry  = &(*pos->corrHists)[stm()][i][keys[i] & CORRECTION_HISTORY_MASK];
+        int32_t  update = (*entry * (ch_v3 - newWeight) + scaledDiff * newWeight) / ch_v3;
 
-        int32_t newWeight  = min(ch_v1, 1 + depth);
-        int32_t scaledDiff = diff * ch_v2;
-        int32_t update     = *entry * (ch_v3 - newWeight) + scaledDiff * newWeight;
-
-        *entry = max(-CORRECTION_HISTORY_MAX, min(CORRECTION_HISTORY_MAX, update / ch_v3));
+        *entry = clamp(update, -CORRECTION_HISTORY_MAX, CORRECTION_HISTORY_MAX);
     }
 }
 


### PR DESCRIPTION
```
Elo   | -0.15 +- 1.33 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.30 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 75780 W: 18489 L: 18522 D: 38769
Penta | [459, 9211, 18542, 9260, 418]
```

```
Mean #0: Total 236378 Mean 29841.37
Stdev #0: Total 236378 Stdev 414091.03
```
```
Mean #0: Total 249637 Mean -290.01
Stdev #0: Total 249637 Stdev 14074.98
```