### PR TITLE
Quadratic correction history formula

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1221,7 +1221,7 @@ static void update_correction_histories(const Position* pos, Depth depth, int32_
     Key keys[] = {pawn_key(),      prev_move_key(), w_nonpawn_key(),
                   b_nonpawn_key(), minor_key(),     major_key()};
 
-    int32_t newWeight  = min(ch_v1, depth * depth / 2 + 2 * depth + 4);
+    int32_t newWeight  = min(ch_v1, depth * depth + 4 * depth + 4);
     int32_t scaledDiff = clamp(diff * ch_v2, -32768, 32768);
 
 #pragma clang loop unroll(disable)


### PR DESCRIPTION
```
Elo   | 3.58 +- 2.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22426 W: 5553 L: 5322 D: 11551
Penta | [109, 2635, 5513, 2828, 128]
```