### PR TITLE
Modernize continuation history based pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -750,7 +750,7 @@ moves_loop:  // When in check search starts from here.
             }
             else
             {
-                // Countermoves based pruning
+                // Continuation history based pruning
                 if (lmrDepth < cbp_v1
                     && (*contHist0)[movedType][to_sq(move)] + (*contHist1)[movedType][to_sq(move)]
                          < -cbp_v2 * depth + cbp_v3)


### PR DESCRIPTION
Started as a non-regression for better alignment with modern CHP but it also passes [0, 5] (LLR: 3.3935).
 
```
Elo   | 6.43 +- 3.92 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 8588 W: 2169 L: 2010 D: 4409
Penta | [36, 980, 2125, 1095, 58]
```