### PR TITLE
Remove last capture extensions

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -238,12 +238,6 @@ static bool non_pawn_material(const Position* pos) {
     return pieces_cpp(stm(), PAWN, KING) != pieces_c(stm());
 }
 
-static bool low_material(const Position* pos) {
-    const Bitboard rooks = pieces_p(ROOK);
-    return pieces_p(QUEEN) == 0 && !more_than_one(rooks)
-        && popcount(pieces_pp(KNIGHT, BISHOP)) + 2 * (rooks != 0) <= 3;
-}
-
 void pos_set_check_info(Position* pos);
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -142,7 +142,6 @@ PARAM(pcmb_v8, 121)
 PARAM(pcmb_v9, 235)
 PARAM(pcmb_v12, 142)
 PARAM(pcmb_v13, 78)
-PARAM(lce_v1, 202)
 PARAM(r_v2, 1981)
 PARAM(r_v3, 1112)
 PARAM(r_v4, 173)
@@ -825,10 +824,6 @@ moves_loop:  // When in check search starts from here.
             ss->mpKillers[0] = k1;
             ss->mpKillers[1] = k2;
         }
-
-        // Last capture extension
-        else if (PieceValue[captured_piece()] > lce_v1 && low_material(pos))
-            extension = 1;
 
         // Add extension to new depth
         newDepth += extension;


### PR DESCRIPTION
Elo   | -0.27 +- 1.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 120608 W: 29838 L: 29932 D: 60838
Penta | [631, 13556, 32009, 13492, 616]

bench: 1995107