### PR TITLE
Increase move count threshold

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -542,7 +542,7 @@ Value search(
                 update_quiet_stats(pos, ss, ttMove, stat_bonus(depth) * hs_v7 / 1024);
 
             // Extra penalty for early quiet moves of the previous ply
-            if ((ss - 1)->moveCount <= 2 && !captured_piece() && prevSq != SQ_NONE)
+            if ((ss - 1)->moveCount <= 3 && !captured_piece() && prevSq != SQ_NONE)
                 update_continuation_histories(ss - 1, piece_on(prevSq), prevSq,
                                               -stat_malus(depth + 1) * hs_v8 / 1024);
         }


### PR DESCRIPTION
```
Elo   | 2.09 +- 1.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40686 W: 6433 L: 6188 D: 28065
Penta | [194, 3721, 12330, 3842, 256]
```