### PR TITLE
Adjust RFP based on cut node

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -619,6 +619,7 @@ Value search(
     // Step 6. Futility pruning: child node
     if (!ss->ttPv
         && eval - futility_margin(depth, improving) + (cv_v1 - cv_v2 * abs(correctionValue) / 1024)
+               - 60 * !cutNode
              >= beta
         && (ttCapture || !ttMove) && beta > -VALUE_MATE_IN_MAX_PLY)
         return eval;


### PR DESCRIPTION
```
Elo   | 1.44 +- 1.17 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 73178 W: 11317 L: 11014 D: 50847
Penta | [309, 6471, 22762, 6702, 345]
```